### PR TITLE
Install GNU awk

### DIFF
--- a/group_vars/all/base.yml
+++ b/group_vars/all/base.yml
@@ -67,6 +67,7 @@ base_developer_tools:
   - fonts-powerline
   - fzf
   - g++
+  - gawk
   - gedit-plugins
   - geoip-bin
   - ghostwriter


### PR DESCRIPTION
On Pop!_OS, `awk` points to `mawk` which is not fully compatible with GNU awk